### PR TITLE
Box label

### DIFF
--- a/CostBenefit/SMRCostBenefit+methods.h
+++ b/CostBenefit/SMRCostBenefit+methods.h
@@ -17,4 +17,8 @@
 
 - (NSMutableArray *)fetchBoxes:(NSManagedObjectContext *)context;
 
+- (NSString *)getBoxLabel:(NSNumber*)boxNumber;
+
+- (NSString *)getVerb;
+
 @end

--- a/CostBenefit/SMRCostBenefit+methods.h
+++ b/CostBenefit/SMRCostBenefit+methods.h
@@ -17,7 +17,9 @@
 
 - (NSMutableArray *)fetchBoxes:(NSManagedObjectContext *)context;
 
-- (NSString *)getBoxLabel:(NSNumber*)boxNumber;
+- (NSString *)getBoxDescriptor:(NSNumber *)boxNumber isPlural:(BOOL)isPlural;
+
+- (NSString *)getBoxLabelText:(NSNumber*)boxNumber isPlural:(BOOL)isPlural;
 
 - (NSString *)getVerb;
 

--- a/CostBenefit/SMRCostBenefit+methods.m
+++ b/CostBenefit/SMRCostBenefit+methods.m
@@ -46,4 +46,18 @@
     return boxes;
 }
 
+- (NSString *)getVerb {
+    NSString *verb;
+    if ([self.type isEqualToString:@"activity"]) {
+        verb = self.title;
+    }
+    else {
+        verb = @"using";
+    }
+    return verb;
+}
+
+- (NSString *)getBoxLabel:(NSNumber*)boxNumber {
+    return @" ";
+}
 @end

--- a/CostBenefit/SMRCostBenefit+methods.m
+++ b/CostBenefit/SMRCostBenefit+methods.m
@@ -57,7 +57,27 @@
     return verb;
 }
 
-- (NSString *)getBoxLabel:(NSNumber*)boxNumber {
-    return @" ";
+- (NSString *)getBoxDescriptor:(NSNumber *)boxNumber isPlural:(BOOL)isPlural {
+    NSString *descriptor;
+    if ([boxNumber intValue] % 2 == 0) {
+        descriptor = @"Advantage";
+    }
+    else {
+        descriptor = @"Disadvantage";
+    }
+    if (isPlural) {
+        descriptor = [NSString stringWithFormat:@"%@s", descriptor];
+    }
+    return descriptor;
+}
+
+- (NSString *)getBoxLabelText:(NSNumber*)boxNumber isPlural:(BOOL)isPlural{
+    NSString *action = @"";
+    if ([boxNumber intValue] > 1) {
+        action = @"NOT ";
+    }
+    NSString *descriptor = [self getBoxDescriptor:boxNumber isPlural:isPlural];
+    NSString *text = [NSString stringWithFormat:@"%@ of %@%@", descriptor, action, [self getVerb]];
+    return text;
 }
 @end

--- a/CostBenefit/SMRCostBenefitItemViewController.m
+++ b/CostBenefit/SMRCostBenefitItemViewController.m
@@ -30,7 +30,7 @@
     self.boxPicker.dataSource = self;
     self.boxPicker.delegate = self;
 
-    NSString *verb = [SMRViewControllerHelper getVerb:self.costBenefit];
+    NSString *verb = [self.costBenefit getVerb];
     _boxOptions =  @[@[@"Advantage",
                        @"Disadvantage"],
                      @[[NSString stringWithFormat:@"of %@", verb],

--- a/CostBenefit/SMRCostBenefitItemViewController.m
+++ b/CostBenefit/SMRCostBenefitItemViewController.m
@@ -13,6 +13,10 @@
 @interface SMRCostBenefitItemViewController ()
 
 @property (strong, nonatomic) NSArray *boxOptions;
+@property (strong, nonatomic) NSString *textAdvantage;
+@property (strong, nonatomic) NSString *textDisadvantage;
+@property (strong, nonatomic) NSString *textLongTerm;
+
 @property (weak, nonatomic) IBOutlet UIPickerView *boxPicker;
 @property (weak, nonatomic) IBOutlet UILabel *longTermLabel;
 @property (weak, nonatomic) IBOutlet UISwitch *longTermSwitch;
@@ -31,11 +35,14 @@
     [super viewDidLoad];
     self.boxPicker.dataSource = self;
     self.boxPicker.delegate = self;
+    self.textAdvantage = [self.costBenefit getBoxDescriptor:[NSNumber numberWithInt:0] isPlural:NO];
+    self.textDisadvantage = [self.costBenefit getBoxDescriptor:[NSNumber numberWithInt:1] isPlural:NO];
+    self.textLongTerm = @"Long-term";
 
     NSString *verb = [self.costBenefit getVerb];
     _boxOptions =  @[@[
-                         [self.costBenefit getBoxDescriptor:[NSNumber numberWithInt:0] isPlural:NO],
-                         [self.costBenefit getBoxDescriptor:[NSNumber numberWithInt:1] isPlural:NO]
+                         self.textAdvantage,
+                         self.textDisadvantage
                          ],
                      @[
                          [NSString stringWithFormat:@"of %@", verb],
@@ -65,6 +72,7 @@
         // Set to Box 0 as default.
         self.costBenefitItem.boxNumber = [NSNumber numberWithInt:0];
     }
+    [self setLongTermLabelText];
     [self.titleTextField addTarget:self
                             action:@selector(editingChanged:)
                   forControlEvents:UIControlEventEditingChanged];
@@ -77,7 +85,6 @@
         case 1:
             [self.boxPicker selectRow:1 inComponent:0 animated:YES];
             [self.boxPicker reloadComponent:0];
-            self.longTermLabel.text = @"Long-term disadvantage";
             break;
         case 2:
             [self.boxPicker selectRow:1 inComponent:1 animated:YES];
@@ -88,11 +95,15 @@
             [self.boxPicker reloadComponent:0];
             [self.boxPicker selectRow:1 inComponent:1 animated:YES];
             [self.boxPicker reloadComponent:1];
-            self.longTermLabel.text = @"Long-term disadvantage";
             break;
         default:
             break;
     }
+    [self setLongTermLabelText];
+}
+
+- (void) setLongTermLabelText {
+    self.longTermLabel.text = [NSString stringWithFormat:@"%@ %@", self.textLongTerm, [self.costBenefit getBoxDescriptor:self.costBenefitItem.boxNumber isPlural:NO]];
 }
 
 -(void) editingChanged:(id)sender {
@@ -105,10 +116,10 @@
 - (void)pickerView:(UIPickerView *)pickerView didSelectRow:(NSInteger)row inComponent:(NSInteger)component{
     if (component == 0) {
         if (row == 0) {
-            self.longTermLabel.text = @"Long-term advantage";
+            self.longTermLabel.text = [NSString stringWithFormat:@"%@ %@", self.textLongTerm, self.textAdvantage];
         }
         else {
-            self.longTermLabel.text = @"Long-term disadvantage";
+            self.longTermLabel.text = [NSString stringWithFormat:@"%@ %@", self.textLongTerm, self.textDisadvantage];
         }
     }
 }

--- a/CostBenefit/SMRCostBenefitItemViewController.m
+++ b/CostBenefit/SMRCostBenefitItemViewController.m
@@ -11,6 +11,7 @@
 #import "SMRViewControllerHelper.h"
 
 @interface SMRCostBenefitItemViewController ()
+
 @property (strong, nonatomic) NSArray *boxOptions;
 @property (weak, nonatomic) IBOutlet UIPickerView *boxPicker;
 @property (weak, nonatomic) IBOutlet UILabel *longTermLabel;
@@ -21,6 +22,7 @@
 - (IBAction)cancelTapped:(id)sender;
 - (IBAction)saveTapped:(id)sender;
 - (IBAction)trashTapped:(id)sender;
+
 @end
 
 @implementation SMRCostBenefitItemViewController
@@ -31,15 +33,28 @@
     self.boxPicker.delegate = self;
 
     NSString *verb = [self.costBenefit getVerb];
-    _boxOptions =  @[@[@"Advantage",
-                       @"Disadvantage"],
-                     @[[NSString stringWithFormat:@"of %@", verb],
-                       [NSString stringWithFormat:@"of NOT %@", verb]]];
+    _boxOptions =  @[@[
+                         [self.costBenefit getBoxDescriptor:[NSNumber numberWithInt:0] isPlural:NO],
+                         [self.costBenefit getBoxDescriptor:[NSNumber numberWithInt:1] isPlural:NO]
+                         ],
+                     @[
+                         [NSString stringWithFormat:@"of %@", verb],
+                         [NSString stringWithFormat:@"of NOT %@", verb]
+                         ]
+                     ];
     self.longTermLabel.text = @"Long-term advantage";
     if (self.costBenefitItem != nil) {
         self.titleTextField.text = self.costBenefitItem.title;
         self.longTermSwitch.on = [self.costBenefitItem.isLongTerm boolValue];
         self.title = @"Edit Item";
+        self.boxPicker.hidden = YES;
+
+        UILabel *boxLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 100, CGRectGetWidth(self.view.bounds), 20)];
+        [boxLabel setTextColor:[UIColor blackColor]];
+        [boxLabel setBackgroundColor:[UIColor clearColor]];
+        [boxLabel setTextAlignment:NSTextAlignmentCenter];
+        [boxLabel setText:[self.costBenefit getBoxLabelText:self.costBenefitItem.boxNumber isPlural:NO]];
+        [self.view addSubview:boxLabel];
     }
     else {
         self.navigationController.toolbarHidden = YES;

--- a/CostBenefit/SMRCostBenefitViewController.m
+++ b/CostBenefit/SMRCostBenefitViewController.m
@@ -58,7 +58,7 @@
 
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section{
     NSString *title;
-    NSString *verb = [SMRViewControllerHelper getVerb:self.costBenefit];
+    NSString *verb = [self.costBenefit getVerb];
 
     switch (section) {
         case 0:

--- a/CostBenefit/SMRCostBenefitViewController.m
+++ b/CostBenefit/SMRCostBenefitViewController.m
@@ -57,26 +57,8 @@
 }
 
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section{
-    NSString *title;
-    NSString *verb = [self.costBenefit getVerb];
-
-    switch (section) {
-        case 0:
-            title = [NSString stringWithFormat:@"Advantages of %@", verb];
-            break;
-        case 1:
-            title = [NSString stringWithFormat:@"Disadvantages of %@", verb];
-            break;
-        case 2:
-            title = [NSString stringWithFormat:@"Advantages of NOT %@", verb];
-            break;
-        case 3:
-            title = [NSString stringWithFormat:@"Disadvantages of NOT %@", verb];
-            break;
-        default:
-            break;
-    }
-    return title;
+    NSNumber *boxNumber = [NSNumber numberWithInteger:section];
+    return [self.costBenefit getBoxLabelText:boxNumber isPlural:YES];
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {

--- a/CostBenefit/SMRViewControllerHelper.h
+++ b/CostBenefit/SMRViewControllerHelper.h
@@ -13,8 +13,6 @@
 
 @interface SMRViewControllerHelper : NSObject
 
-+ (NSString *)getVerb:(SMRCostBenefit *)costBenefit;
-
 + (void)presentCostBenefit:(SMRCostBenefit *)costBenefit viewController:(UIViewController *)viewController context:(NSManagedObjectContext *)context;
 
 + (void)presentHome:(UIViewController *)viewController context:(NSManagedObjectContext *)context;

--- a/CostBenefit/SMRViewControllerHelper.m
+++ b/CostBenefit/SMRViewControllerHelper.m
@@ -12,17 +12,6 @@
 
 @implementation SMRViewControllerHelper
 
-+ (NSString *)getVerb:(SMRCostBenefit *)costBenefit {
-    NSString *verb;
-    if ([costBenefit.type isEqualToString:@"activity"]) {
-        verb = costBenefit.title;
-    }
-    else {
-        verb = @"using";
-    }
-    return verb;
-}
-
 + (void)presentCostBenefit:(SMRCostBenefit *)costBenefit viewController:(UIViewController*)viewController context:(NSManagedObjectContext *)context {
 
     UINavigationController *destNavVC = [viewController.storyboard instantiateViewControllerWithIdentifier:@"costBenefitNavigationController"];


### PR DESCRIPTION
Replaces the `boxPicker` with a static `UILabel` to prevent User from changing a CostBenefitItem's boxNumber. Makes for better UI.

Also adds a bunch of stuff into the `CostBenefit+methods` class to avoid hardcoding strings like "Advantage", "Disadvantage", in case we ever want to change it to something like "Pro" and "Con"
