### PR TITLE
dateCreated

### DIFF
--- a/CostBenefit/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/CostBenefit/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -1,19 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="6751" systemVersion="14C1514" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="7549" systemVersion="14C1514" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
     <entity name="SMRCostBenefit" representedClassName="SMRCostBenefit" syncable="YES">
+        <attribute name="dateCreated" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="title" attributeType="String" syncable="YES"/>
         <attribute name="type" attributeType="String" syncable="YES"/>
         <relationship name="costBenefitItems" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SMRCostBenefitItem" inverseName="costBenefit" inverseEntity="SMRCostBenefitItem" syncable="YES"/>
     </entity>
     <entity name="SMRCostBenefitItem" representedClassName="SMRCostBenefitItem" syncable="YES">
         <attribute name="boxNumber" attributeType="Integer 16" defaultValueString="1" syncable="YES"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="isLongTerm" attributeType="Boolean" defaultValueString="YES" syncable="YES"/>
         <attribute name="seq" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
         <attribute name="title" attributeType="String" syncable="YES"/>
         <relationship name="costBenefit" maxCount="1" deletionRule="Nullify" destinationEntity="SMRCostBenefit" inverseName="costBenefitItems" inverseEntity="SMRCostBenefit" syncable="YES"/>
     </entity>
     <elements>
-        <element name="SMRCostBenefit" positionX="-288" positionY="-13" width="128" height="88"/>
-        <element name="SMRCostBenefitItem" positionX="-54" positionY="-18" width="128" height="120"/>
+        <element name="SMRCostBenefit" positionX="-288" positionY="-13" width="128" height="105"/>
+        <element name="SMRCostBenefitItem" positionX="-54" positionY="-18" width="128" height="135"/>
     </elements>
 </model>

--- a/CostBenefit/SMRCostBenefit+methods.m
+++ b/CostBenefit/SMRCostBenefit+methods.m
@@ -23,6 +23,11 @@
     NSEntityDescription *entity = [NSEntityDescription entityForName:@"SMRCostBenefit"
                                               inManagedObjectContext:context];
     [fetchRequest setEntity:entity];
+
+    NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc]
+                                        initWithKey:@"dateCreated" ascending:YES];
+    [fetchRequest setSortDescriptors:@[sortDescriptor]];
+
     NSError *error = nil;
 
     return (NSMutableArray *)[context executeFetchRequest:fetchRequest error:&error];
@@ -38,6 +43,10 @@
         [fetchRequest setEntity:entity];
         NSPredicate *predicate = [NSPredicate predicateWithFormat:@"(costBenefit == %@) AND (boxNumber == %@)", self, [NSNumber numberWithInt:i]];
         [fetchRequest setPredicate:predicate];
+
+        NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc]
+                                            initWithKey:@"dateCreated" ascending:YES];
+        [fetchRequest setSortDescriptors:@[sortDescriptor]];
         NSError *error = nil;
 
         NSMutableArray *boxItems = (NSMutableArray *)[context executeFetchRequest:fetchRequest error:&error];

--- a/CostBenefit/SMRCostBenefit.h
+++ b/CostBenefit/SMRCostBenefit.h
@@ -15,6 +15,7 @@
 @property (nonatomic, retain) NSString * title;
 @property (nonatomic, retain) NSString * type;
 @property (nonatomic, retain) NSSet *costBenefitItems;
+@property (nonatomic, retain) NSDate * dateCreated;
 @end
 
 @interface SMRCostBenefit (CoreDataGeneratedAccessors)

--- a/CostBenefit/SMRCostBenefit.m
+++ b/CostBenefit/SMRCostBenefit.m
@@ -13,6 +13,7 @@
 
 @dynamic title;
 @dynamic type;
+@dynamic dateCreated;
 @dynamic costBenefitItems;
 
 @end

--- a/CostBenefit/SMRCostBenefitItem.h
+++ b/CostBenefit/SMRCostBenefitItem.h
@@ -17,6 +17,7 @@
 @property (nonatomic, retain) NSNumber * seq;
 @property (nonatomic, retain) NSNumber * boxNumber;
 @property (nonatomic, retain) NSNumber * isLongTerm;
+@property (nonatomic, retain) NSDate * dateCreated;
 @property (nonatomic, retain) SMRCostBenefit *costBenefit;
 
 @end

--- a/CostBenefit/SMRCostBenefitItem.m
+++ b/CostBenefit/SMRCostBenefitItem.m
@@ -16,6 +16,7 @@
 @dynamic seq;
 @dynamic boxNumber;
 @dynamic isLongTerm;
+@dynamic dateCreated;
 @dynamic costBenefit;
 
 @end

--- a/CostBenefit/SMRCostBenefitItemViewController.m
+++ b/CostBenefit/SMRCostBenefitItemViewController.m
@@ -169,6 +169,7 @@
     }
     if ([self.op isEqualToString:@"insert"]) {
         [self.costBenefit addCostBenefitItemsObject:(NSManagedObject *)self.costBenefitItem];
+        self.costBenefitItem.dateCreated = [[NSDate alloc] init];
     }
     NSError *error;
     [self.context save:&error];

--- a/CostBenefit/SMREditCostBenefitViewController.m
+++ b/CostBenefit/SMREditCostBenefitViewController.m
@@ -126,6 +126,7 @@
 
     if ([self.op isEqualToString:@"insert"]) {
         self.costBenefit = [SMRCostBenefit createCostBenefitInContext:self.context];
+        self.costBenefit.dateCreated = [[NSDate alloc] init];
     }
     self.costBenefit.title = self.titleTextField.text;
     self.costBenefit.type = self.costBenefitType;


### PR DESCRIPTION
Redoes the work in https://github.com/smartrecovery/costbenefit.objc/commit/f8cdb35e1ff3ea73285c5d82e042ee0fe5ea0579 to add a `dateCreated` property to both `CostBenefit` and `CostBenefitItem` entities.

Resolves #14
