### PR TITLE
Delete CostBenefitItem from its Edit View

### DIFF
--- a/CostBenefit/Controllers/SMRCostBenefitBoxViewController.m
+++ b/CostBenefit/Controllers/SMRCostBenefitBoxViewController.m
@@ -66,7 +66,7 @@
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
 
-    if (self.costBenefitItems.count == 0) {
+    if (self.costBenefitItems.count < 2) {
         self.editBoxButton.hidden = YES;
     }
     else {
@@ -156,18 +156,12 @@ canEditRowAtIndexPath:(NSIndexPath *)indexPath {
     return YES;
 }
 
-- (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (editingStyle == UITableViewCellEditingStyleDelete) {
-        self.didEditBox = YES;
-        SMRCostBenefitItem *costBenefitItem = (SMRCostBenefitItem *)self.costBenefitItems[indexPath.row];
-        [self.costBenefit removeCostBenefitItemsObject:(NSManagedObject *)costBenefitItem];
-        [self.managedObjectContext deleteObject:costBenefitItem];
-        [self.costBenefit setDateUpdated:[[NSDate alloc] init]];
-        NSError *error;
-        [self.managedObjectContext save:&error];
-        self.costBenefitItems = [self.costBenefit loadItemsForBoxNumber:self.boxNumber managedObjectContext:self.managedObjectContext];
-        [tableView deleteRowsAtIndexPaths:[NSArray arrayWithObject:indexPath] withRowAnimation:UITableViewRowAnimationLeft];
-    }
+- (UITableViewCellEditingStyle)tableView:(UITableView *)tableView editingStyleForRowAtIndexPath:(NSIndexPath *)indexPath {
+    return UITableViewCellEditingStyleNone;
+}
+
+- (BOOL)tableView:(UITableView *)tableview shouldIndentWhileEditingRowAtIndexPath:(NSIndexPath *)indexPath {
+    return NO;
 }
 
 - (BOOL)tableView:(UITableView *)tableView canMoveRowAtIndexPath:(NSIndexPath *)indexPath {

--- a/CostBenefit/Controllers/SMREditCostBenefitItemViewController.m
+++ b/CostBenefit/Controllers/SMREditCostBenefitItemViewController.m
@@ -16,12 +16,15 @@
 @property (strong, nonatomic) SMRCostBenefitItem *costBenefitItem;
 @property (strong, nonatomic) UIBarButtonItem *cancelButton;
 @property (strong, nonatomic) UIBarButtonItem *saveButton;
+@property (weak, nonatomic) IBOutlet UIButton *deleteButton;
 
 @property (weak, nonatomic) IBOutlet UILabel *boxDescriptionLabel;
 @property (weak, nonatomic) IBOutlet UITextField *costBenefitItemTitleField;
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
 
 - (IBAction)CostBenefitItemTitleFieldEditingChanged:(id)sender;
+- (IBAction)deleteButtonTouchUpInside:(id)sender;
+
 
 @end
 
@@ -52,10 +55,12 @@
 
     if (self.isNew) {
         self.title = @"New Item";
+        self.deleteButton.hidden = YES;
     }
     else {
         self.title = @"Edit Item";
         self.costBenefitItemTitleField.text = self.costBenefitItem.title;
+        self.deleteButton.hidden = NO;
     }
 
     self.cancelButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelButtonTapped:)];
@@ -102,6 +107,27 @@
     else {
         self.saveButton.enabled = YES;
     }
+}
+
+- (IBAction)deleteButtonTouchUpInside:(id)sender {
+    UIAlertController *confirmDeleteAlertController = [UIAlertController alertControllerWithTitle:@"Are you sure you want to delete this item?" message:@"This cannot be undone." preferredStyle:UIAlertControllerStyleAlert];
+    UIAlertAction *deleteAction = [UIAlertAction actionWithTitle:@"Delete" style:UIAlertActionStyleDestructive handler:^(UIAlertAction * action) {
+        [self.costBenefitItem.costBenefit setDateCreated:[[NSDate alloc] init]];
+        [self.costBenefitItem.costBenefit removeCostBenefitItemsObject:self.costBenefitItem];
+        [self.managedObjectContext deleteObject:self.costBenefitItem];
+        NSError *error;
+        [self.managedObjectContext save:&error];
+        UINavigationController *presentingVC = (UINavigationController *)self.presentingViewController;
+        SMRCostBenefitViewController *destVC = (SMRCostBenefitViewController *)presentingVC.topViewController;
+        destVC.managedObjectContext = self.managedObjectContext;
+        [self.navigationController dismissViewControllerAnimated:YES completion:nil];
+    }];
+    UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action) {
+    }];
+    [confirmDeleteAlertController addAction:deleteAction];
+    [confirmDeleteAlertController addAction:cancelAction];
+
+     [self presentViewController:confirmDeleteAlertController animated:YES completion:nil];
 }
 
 #pragma mark - UITextFieldDelegate

--- a/CostBenefit/Views/SMREditCostBenefitItemView.xib
+++ b/CostBenefit/Views/SMREditCostBenefitItemView.xib
@@ -9,6 +9,7 @@
             <connections>
                 <outlet property="boxDescriptionLabel" destination="dxa-Fy-ccz" id="5Rn-HM-aRZ"/>
                 <outlet property="costBenefitItemTitleField" destination="XIp-FU-VQY" id="1qP-bA-CVf"/>
+                <outlet property="deleteButton" destination="hea-jx-lX5" id="Wxd-2L-37s"/>
                 <outlet property="tableView" destination="8Rm-aZ-6tV" id="C4t-C8-ext"/>
                 <outlet property="view" destination="iN0-l3-epB" id="HJw-FA-RBH"/>
             </connections>
@@ -33,26 +34,38 @@
                     </connections>
                 </textField>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" bounces="NO" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="8Rm-aZ-6tV">
-                    <rect key="frame" x="8" y="83" width="584" height="509"/>
+                    <rect key="frame" x="8" y="83" width="584" height="399"/>
                     <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                     <connections>
                         <outlet property="dataSource" destination="-1" id="wuQ-2n-0Iu"/>
                         <outlet property="delegate" destination="-1" id="tZp-Ik-byE"/>
                     </connections>
                 </tableView>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hea-jx-lX5">
+                    <rect key="frame" x="8" y="526" width="584" height="30"/>
+                    <state key="normal" title="Delete Item">
+                        <color key="titleColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                    </state>
+                    <connections>
+                        <action selector="deleteButtonTouchUpInside:" destination="-1" eventType="touchUpInside" id="L2r-Ux-OHg"/>
+                    </connections>
+                </button>
             </subviews>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
             <constraints>
+                <constraint firstItem="hea-jx-lX5" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="AYz-Kl-1qH"/>
                 <constraint firstAttribute="trailing" secondItem="dxa-Fy-ccz" secondAttribute="trailing" constant="8" id="CQo-63-VyG"/>
                 <constraint firstAttribute="trailing" secondItem="XIp-FU-VQY" secondAttribute="trailing" constant="8" id="REy-0W-dUI"/>
                 <constraint firstItem="XIp-FU-VQY" firstAttribute="top" secondItem="dxa-Fy-ccz" secondAttribute="bottom" constant="8" id="RRV-Ba-i8X"/>
-                <constraint firstAttribute="bottom" secondItem="8Rm-aZ-6tV" secondAttribute="bottom" constant="8" id="SR4-tG-diQ"/>
                 <constraint firstItem="XIp-FU-VQY" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="Yr3-jJ-BoI"/>
+                <constraint firstAttribute="trailing" secondItem="hea-jx-lX5" secondAttribute="trailing" constant="8" id="ZZz-5U-vof"/>
                 <constraint firstItem="dxa-Fy-ccz" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="dmu-7m-iwp"/>
                 <constraint firstAttribute="trailing" secondItem="8Rm-aZ-6tV" secondAttribute="trailing" constant="8" id="g3k-cq-Qp2"/>
                 <constraint firstItem="8Rm-aZ-6tV" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="iWR-vN-Soj"/>
+                <constraint firstAttribute="bottom" secondItem="hea-jx-lX5" secondAttribute="bottom" constant="44" id="pUS-Ty-qZ4"/>
                 <constraint firstItem="dxa-Fy-ccz" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="16" id="rat-5t-1Wl"/>
                 <constraint firstItem="8Rm-aZ-6tV" firstAttribute="top" secondItem="XIp-FU-VQY" secondAttribute="bottom" constant="8" id="u4V-Yb-7aE"/>
+                <constraint firstItem="hea-jx-lX5" firstAttribute="top" secondItem="8Rm-aZ-6tV" secondAttribute="bottom" constant="44" id="ubV-Yw-pi2"/>
             </constraints>
         </view>
     </objects>


### PR DESCRIPTION
Simplifies editing the box `tableView` by only allowing sorting from the `SMRCostBenefitBoxViewController`. Adds a `deleteButton` to the `SMREditCostBenefitItemViewController` to provide delete functionality, and refresh the presenting view controller's data. Fixes #55 
