### PR TITLE
Fixes bug on add CostBenefitItem screen

### DIFF
--- a/CostBenefit/Controllers/SMREditCostBenefitItemViewController.m
+++ b/CostBenefit/Controllers/SMREditCostBenefitItemViewController.m
@@ -190,7 +190,9 @@ didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     else {
         self.costBenefitItem.isLongTerm = [NSNumber numberWithBool:NO];
     }
-    self.saveButton.enabled = YES;
+    if (self.costBenefitItemTitleField.text.length > 2) {
+        self.saveButton.enabled = YES;
+    }
     [self.tableView reloadData];
 }
 


### PR DESCRIPTION
Closes #58 - don't allow saving CostBenefitItem unless the title length is at least 2 characters long.
