### PR TITLE
Theming tweaks

### DIFF
--- a/CostBenefit/Controllers/About/SMRAboutCostBenefitViewController.m
+++ b/CostBenefit/Controllers/About/SMRAboutCostBenefitViewController.m
@@ -31,7 +31,7 @@
     NSString *content = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:NULL];
     NSString *htmlString = [MMMarkdown HTMLStringWithMarkdown:content error:&error];
     UIFont *systemFont = [UIFont systemFontOfSize:14];
-    NSString *aboutHTML = [NSString stringWithFormat:@"<html><head><style type=\"text/css\">body {font-family: \"%@\";}</style></head><body>%@</body></html>", systemFont.familyName, htmlString];
+    NSString *aboutHTML = [NSString stringWithFormat:@"<html><head><style type=\"text/css\">body {font-family: \"%@\";font-size: %f;}h3{border-bottom:1pt #ddd solid;border-top:1pt #ddd solid;padding:8pt 0 8pt 0}ul{background:#eee; padding: 10pt 10pt 10pt 20pt}li{padding:0 0 10pt 0;}</style></head><body>%@</body></html>", systemFont.familyName, 15.0f, htmlString];
     [self.webView loadHTMLString:aboutHTML baseURL:[[NSBundle mainBundle] bundleURL]];
 }
 

--- a/CostBenefit/Controllers/About/SMRAboutSmartRecoveryViewController.m
+++ b/CostBenefit/Controllers/About/SMRAboutSmartRecoveryViewController.m
@@ -41,8 +41,8 @@
     NSString *path = [[NSBundle mainBundle] pathForResource:@"smart" ofType:@"txt"];
     NSString *content = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:NULL];
     NSString *htmlString = [MMMarkdown HTMLStringWithMarkdown:content error:&error];
-    UIFont *systemFont = [UIFont systemFontOfSize:14];
-    NSString *aboutHTML = [NSString stringWithFormat:@"<html><head><style type=\"text/css\">body {font-family: \"%@\";font-size: %f;}</style></head><body>%@</body></html>", systemFont.familyName, 17.0f, htmlString];
+    UIFont *systemFont = [UIFont systemFontOfSize:15];
+    NSString *aboutHTML = [NSString stringWithFormat:@"<html><head><style type=\"text/css\">body {font-family: \"%@\";font-size: %f;}</style></head><body>%@</body></html>", systemFont.familyName, 15.0f, htmlString];
     NSDictionary *options = @{NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType};
     self.aboutCopyLabel.attributedText = [[NSAttributedString alloc] initWithData:[aboutHTML dataUsingEncoding:NSUTF8StringEncoding] options:options documentAttributes:nil error:&error];
 }

--- a/CostBenefit/Controllers/CostBenefit/SMRCostBenefitBoxViewController.m
+++ b/CostBenefit/Controllers/CostBenefit/SMRCostBenefitBoxViewController.m
@@ -66,7 +66,11 @@
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
 
+    self.tableView.bounces = YES;
     if (self.costBenefitItems.count < 2) {
+        if (self.costBenefitItems.count == 0) {
+            self.tableView.bounces = NO;
+        }
         self.editBoxButton.hidden = YES;
     }
     else {

--- a/CostBenefit/Controllers/CostBenefit/SMRCostBenefitBoxViewController.m
+++ b/CostBenefit/Controllers/CostBenefit/SMRCostBenefitBoxViewController.m
@@ -178,11 +178,11 @@ viewForFooterInSection:(NSInteger)section {
         return nil;
     }
     UIView *footerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, tableView.frame.size.width, 44)];
-    UILabel *titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(10, 5, tableView.frame.size.width - 16, 144)];
+    UILabel *titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(8, 0, tableView.frame.size.width - 16, 144)];
     titleLabel.textAlignment = NSTextAlignmentCenter;
     titleLabel.textColor = UIColor.grayColor;
     titleLabel.numberOfLines = 0;
-    UILabel *copyLabel = [[UILabel alloc] initWithFrame:CGRectMake(10, 144, tableView.frame.size.width - 16, 144)];
+    UILabel *copyLabel = [[UILabel alloc] initWithFrame:CGRectMake(8, 144, tableView.frame.size.width - 16, 72)];
     copyLabel.numberOfLines = 0;
     copyLabel.font = [UIFont systemFontOfSize:14];
     switch ([self.boxNumber intValue]) {

--- a/CostBenefit/Controllers/CostBenefit/SMRCostBenefitBoxViewController.m
+++ b/CostBenefit/Controllers/CostBenefit/SMRCostBenefitBoxViewController.m
@@ -57,7 +57,7 @@
 
     self.costBenefitItems = [self.costBenefit loadItemsForBoxNumber:self.boxNumber managedObjectContext:self.managedObjectContext];
 
-    self.boxHeaderLabel.text = [self.costBenefit getBoxLabelText:self.boxNumber isPlural:YES];
+    self.boxHeaderLabel.text = [self.costBenefit getBoxLabelText:self.boxNumber isPlural:YES].uppercaseString;
     self.didEditBox = NO;
     self.tableView.editing = NO;
     self.editBoxButton.hidden = YES;
@@ -84,7 +84,7 @@
 #pragma mark - SMRCostBenefitBoxViewController
 
 - (void)reloadData {
-    self.boxHeaderLabel.text = [self.costBenefit getBoxLabelText:self.boxNumber isPlural:YES];
+    self.boxHeaderLabel.text = [self.costBenefit getBoxLabelText:self.boxNumber isPlural:YES].uppercaseString;
     self.costBenefitItems = [self.costBenefit loadItemsForBoxNumber:self.boxNumber managedObjectContext:self.managedObjectContext];
     [self.tableView reloadData];
 }

--- a/CostBenefit/Controllers/CostBenefit/SMRCostBenefitBoxViewController.m
+++ b/CostBenefit/Controllers/CostBenefit/SMRCostBenefitBoxViewController.m
@@ -204,7 +204,7 @@ viewForFooterInSection:(NSInteger)section {
             break;
         case 3:
             titleLabel.text = @"What won't I like about giving up my addiction?";
-            copyLabel.text = @"List what you think you are going to hate, dread or merely dislike about living without your addiction.";
+            copyLabel.text = @"List what you think you are going to hate, dread, or merely dislike about living without your addiction.";
             break;
     }
     [footerView addSubview:titleLabel];

--- a/CostBenefit/Controllers/CostBenefit/SMRCostBenefitViewController.m
+++ b/CostBenefit/Controllers/CostBenefit/SMRCostBenefitViewController.m
@@ -64,7 +64,7 @@
 - (void)styleView {
     self.pageViewController.view.backgroundColor = UIColor.whiteColor;
     UIPageControl *pageControl = [UIPageControl appearance];
-    pageControl.pageIndicatorTintColor = [UIColor lightGrayColor];
+    pageControl.pageIndicatorTintColor = [UIColor colorWithRed:0.867 green:0.867 blue:0.867 alpha:1];
     pageControl.currentPageIndicatorTintColor = self.view.tintColor;
 }
 

--- a/CostBenefit/Controllers/CostBenefit/SMRCostBenefitViewController.m
+++ b/CostBenefit/Controllers/CostBenefit/SMRCostBenefitViewController.m
@@ -87,31 +87,11 @@
         [self.navigationController presentViewController:destNavVC animated:YES completion:nil];
     }];
 
-
-    UIAlertAction *deleteAlertAction = [UIAlertAction actionWithTitle:@"Delete CBA" style:UIAlertActionStyleDestructive handler:^(UIAlertAction * action){
-
-        UIAlertController *confirmDeleteAlertController = [UIAlertController alertControllerWithTitle:@"Are you sure you want to delete this CBA?" message:@"This cannot be undone." preferredStyle:UIAlertControllerStyleAlert];
-
-        UIAlertAction *deleteAction = [UIAlertAction actionWithTitle:@"Delete" style:UIAlertActionStyleDestructive handler:^(UIAlertAction * action) {
-            [self.managedObjectContext deleteObject:self.costBenefit];
-            NSError *error;
-            [self.managedObjectContext save:&error];
-            [self.navigationController popToRootViewControllerAnimated:YES];
-        }];
-        UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action) {
-        }];
-        [confirmDeleteAlertController addAction:deleteAction];
-        [confirmDeleteAlertController addAction:cancelAction];
-
-        [self presentViewController:confirmDeleteAlertController animated:YES completion:nil];
-    }];
-
     UIAlertAction *cancelAlertAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(UIAlertAction * action) {
         [menuAlertController dismissViewControllerAnimated:YES completion:nil];
     }];
 
     [menuAlertController addAction:editAlertAction];
-    [menuAlertController addAction:deleteAlertAction];
     [menuAlertController addAction:cancelAlertAction];
     [self presentViewController:menuAlertController animated:YES completion:nil];
 }

--- a/CostBenefit/Controllers/CostBenefit/SMREditCostBenefitItemViewController.m
+++ b/CostBenefit/Controllers/CostBenefit/SMREditCostBenefitItemViewController.m
@@ -16,14 +16,12 @@
 @property (strong, nonatomic) SMRCostBenefitItem *costBenefitItem;
 @property (strong, nonatomic) UIBarButtonItem *cancelButton;
 @property (strong, nonatomic) UIBarButtonItem *saveButton;
-@property (weak, nonatomic) IBOutlet UIButton *deleteButton;
 
 @property (weak, nonatomic) IBOutlet UILabel *boxDescriptionLabel;
 @property (weak, nonatomic) IBOutlet UITextField *costBenefitItemTitleField;
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
 
 - (IBAction)CostBenefitItemTitleFieldEditingChanged:(id)sender;
-- (IBAction)deleteButtonTouchUpInside:(id)sender;
 
 
 @end
@@ -55,12 +53,14 @@
 
     if (self.isNew) {
         self.title = @"New Item";
-        self.deleteButton.hidden = YES;
     }
     else {
         self.title = @"Edit Item";
         self.costBenefitItemTitleField.text = self.costBenefitItem.title;
-        self.deleteButton.hidden = NO;
+        self.navigationController.toolbarHidden = NO;
+        UIBarButtonItem *trashBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemTrash target:self action:@selector(deleteButtonTouchUpInside:)];
+        NSArray *items = [NSArray arrayWithObjects:trashBarButtonItem, nil];
+        self.toolbarItems = items;
     }
 
     self.cancelButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelButtonTapped:)];

--- a/CostBenefit/Controllers/CostBenefit/SMREditCostBenefitItemViewController.m
+++ b/CostBenefit/Controllers/CostBenefit/SMREditCostBenefitItemViewController.m
@@ -135,8 +135,7 @@
     }];
     [confirmDeleteAlertController addAction:deleteAction];
     [confirmDeleteAlertController addAction:cancelAction];
-
-     [self presentViewController:confirmDeleteAlertController animated:YES completion:nil];
+    [self presentViewController:confirmDeleteAlertController animated:YES completion:nil];
 }
 
 #pragma mark - UITextFieldDelegate

--- a/CostBenefit/Controllers/CostBenefit/SMREditCostBenefitItemViewController.m
+++ b/CostBenefit/Controllers/CostBenefit/SMREditCostBenefitItemViewController.m
@@ -73,6 +73,14 @@
     self.boxDescriptionLabel.text = [NSString stringWithFormat:@"%@ is:", [costBenefit getBoxLabelText:self.costBenefitItem.boxNumber isPlural:NO]].uppercaseString;
 }
 
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+
+    if (self.isNew) {
+        [self.costBenefitItemTitleField becomeFirstResponder];
+    }
+}
+
 #pragma mark - SMREditCostBenefitItemViewController
 
 - (void)cancelButtonTapped:(id)sender {
@@ -81,7 +89,8 @@
 }
 
 - (void)saveButtonTouchUpInside:(id)sender {
-    self.costBenefitItem.title = self.costBenefitItemTitleField.text;
+    self.costBenefitItem.title = [self.costBenefitItemTitleField.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    // @todo: This should be calculated to go to the end... or first
     self.costBenefitItem.seq = [NSNumber numberWithInt:10];
     self.costBenefitItem.costBenefit.dateUpdated = [[NSDate alloc] init];
     if (self.isNew) {

--- a/CostBenefit/Controllers/CostBenefit/SMREditCostBenefitItemViewController.m
+++ b/CostBenefit/Controllers/CostBenefit/SMREditCostBenefitItemViewController.m
@@ -70,7 +70,7 @@
     self.saveButton.enabled = NO;
 
     SMRCostBenefit *costBenefit = self.costBenefitItem.costBenefit;
-    self.boxDescriptionLabel.text = [NSString stringWithFormat:@"%@ is:", [costBenefit getBoxLabelText:self.costBenefitItem.boxNumber isPlural:NO]];
+    self.boxDescriptionLabel.text = [NSString stringWithFormat:@"%@ is:", [costBenefit getBoxLabelText:self.costBenefitItem.boxNumber isPlural:NO]].uppercaseString;
 }
 
 #pragma mark - SMREditCostBenefitItemViewController
@@ -148,10 +148,11 @@
          cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"rowCell"];
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
-    cell.textLabel.font = [UIFont systemFontOfSize:14.0];
+    cell.textLabel.font = [UIFont systemFontOfSize:13.0];
+    cell.textLabel.textColor = UIColor.darkGrayColor;
 
     if (indexPath.row == 0) {
-        cell.textLabel.text = @"Long-term";
+        cell.textLabel.text = @"Long-term".uppercaseString;
         if ([self.costBenefitItem.isLongTerm boolValue]) {
             cell.accessoryType = UITableViewCellAccessoryCheckmark;
         }
@@ -160,7 +161,7 @@
         }
     }
     else {
-        cell.textLabel.text = @"Short-term";
+        cell.textLabel.text = @"Short-term".uppercaseString;
         if ([self.costBenefitItem.isLongTerm boolValue]) {
             cell.accessoryType = UITableViewCellAccessoryNone;
         }
@@ -168,14 +169,6 @@
             cell.accessoryType = UITableViewCellAccessoryCheckmark;
         }
     }
-    NSString *descriptor;
-    if ([self.costBenefitItem.boxNumber intValue] % 2) {
-        descriptor = @"disadvantage";
-    }
-    else {
-        descriptor = @"advantage";
-    }
-    cell.textLabel.text = [NSString stringWithFormat:@"%@ %@", cell.textLabel.text, descriptor];
 
     return cell;
 }

--- a/CostBenefit/Controllers/CostBenefit/SMREditCostBenefitViewController.m
+++ b/CostBenefit/Controllers/CostBenefit/SMREditCostBenefitViewController.m
@@ -60,6 +60,10 @@
     else {
         self.title = @"Edit CBA";
         self.titleTextField.text = self.costBenefit.title;
+        self.navigationController.toolbarHidden = NO;
+        UIBarButtonItem *trashBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemTrash target:self action:@selector(deleteButtonTouchUpInside:)];
+        NSArray *items = [NSArray arrayWithObjects:trashBarButtonItem, nil];
+        self.toolbarItems = items;
     }
     [self.tableView registerClass:[UITableViewCell class] forCellReuseIdentifier:@"rowCell"];
 
@@ -187,6 +191,27 @@
     else {
         self.saveButton.enabled = YES;
     }
+}
+
+- (IBAction)deleteButtonTouchUpInside:(id)sender {
+
+    UIAlertController *confirmDeleteAlertController = [UIAlertController alertControllerWithTitle:@"Are you sure you want to delete this CBA?" message:@"All items will be deleted as well. This cannot be undone." preferredStyle:UIAlertControllerStyleAlert];
+
+    UIAlertAction *deleteAction = [UIAlertAction actionWithTitle:@"Delete" style:UIAlertActionStyleDestructive handler:^(UIAlertAction * action) {
+        [self.managedObjectContext deleteObject:self.costBenefit];
+        NSError *error;
+        [self.managedObjectContext save:&error];
+        UINavigationController *presentingVC = (UINavigationController *)self.presentingViewController;
+        [self.navigationController dismissViewControllerAnimated:YES completion:^{
+            // Pop back to Home VC.
+            [presentingVC popToRootViewControllerAnimated:YES];
+        }];
+    }];
+    UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action) {
+    }];
+    [confirmDeleteAlertController addAction:deleteAction];
+    [confirmDeleteAlertController addAction:cancelAction];
+    [self presentViewController:confirmDeleteAlertController animated:YES completion:nil];
 }
 
 #pragma mark - UITextFieldDelegate

--- a/CostBenefit/Controllers/CostBenefit/SMREditCostBenefitViewController.m
+++ b/CostBenefit/Controllers/CostBenefit/SMREditCostBenefitViewController.m
@@ -16,6 +16,7 @@
 @property (strong, nonatomic) UIBarButtonItem *cancelButton;
 @property (strong, nonatomic) UIBarButtonItem *saveButton;
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
+@property (weak, nonatomic) IBOutlet UILabel *titleTextFieldLabel;
 
 @property (weak, nonatomic) IBOutlet UITextField *titleTextField;
 
@@ -61,9 +62,21 @@
     self.saveButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(saveButtonTouchUpInside:)];
     self.navigationItem.rightBarButtonItem = self.saveButton;
     self.saveButton.enabled = NO;
+    self.titleTextFieldLabel.text = @"to consider is:".uppercaseString;
+    [self setPlaceholderText];
+
 }
 
 #pragma mark - SMREditCostBenefitItemViewController
+
+- (void)setPlaceholderText {
+    if ([self.costBenefit.type isEqualToString:@"substance"]) {
+        self.titleTextField.placeholder = @"Substance name, e.g. alcohol, nicotine";
+    }
+    else {
+        self.titleTextField.placeholder = @"Activity name, e.g. gambling, procrastinating";
+    }
+}
 
 - (void)cancelButtonTapped:(id)sender {
     [self.managedObjectContext rollback];
@@ -119,7 +132,7 @@
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
 
     if (indexPath.row == 0) {
-        cell.textLabel.text = @"The substance";
+        cell.textLabel.text = @"The substance".uppercaseString;
         if ([self.costBenefit.type isEqualToString:@"substance"]) {
             cell.accessoryType = UITableViewCellAccessoryCheckmark;
         }
@@ -128,7 +141,7 @@
         }
     }
     else {
-        cell.textLabel.text = @"The activity";
+        cell.textLabel.text = @"The activity".uppercaseString;
         if ([self.costBenefit.type isEqualToString:@"activity"]) {
             cell.accessoryType = UITableViewCellAccessoryCheckmark;
         }
@@ -136,6 +149,8 @@
             cell.accessoryType = UITableViewCellAccessoryNone;
         }
     }
+    cell.textLabel.font = [UIFont systemFontOfSize:13.0];
+    cell.textLabel.textColor = UIColor.darkGrayColor;
 
     return cell;
 }
@@ -153,6 +168,7 @@ didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     if (self.titleTextField.text.length > 2) {
         self.saveButton.enabled = YES;
     }
+    [self setPlaceholderText];
     [self.tableView reloadData];
 }
 

--- a/CostBenefit/Controllers/CostBenefit/SMREditCostBenefitViewController.m
+++ b/CostBenefit/Controllers/CostBenefit/SMREditCostBenefitViewController.m
@@ -74,6 +74,14 @@
 
 }
 
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+
+    if (self.isNew) {
+        [self.titleTextField becomeFirstResponder];
+    }
+}
+
 #pragma mark - SMREditCostBenefitItemViewController
 
 - (void)startListeningForNotifications {
@@ -153,7 +161,8 @@
 
 - (void)saveButtonTouchUpInside:(id)sender {
     self.costBenefit.dateUpdated = [[NSDate alloc] init];
-    self.costBenefit.title = self.titleTextField.text;
+    self.costBenefit.title = [self.titleTextField.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+
     NSError *error;
     [self.managedObjectContext save:&error];
 

--- a/CostBenefit/Models/SMRCostBenefit+methods.m
+++ b/CostBenefit/Models/SMRCostBenefit+methods.m
@@ -65,10 +65,11 @@
 
 - (NSString *)getVerb {
     if ([self.type isEqualToString:@"activity"]) {
-        return @"doing";
+        return @"doing it";
     }
     return @"using";
 }
+
 
 - (NSString *)getBoxDescriptor:(NSNumber *)boxNumber isPlural:(BOOL)isPlural {
     NSString *descriptor;
@@ -99,7 +100,18 @@
         action = @"NOT ";
     }
     NSString *descriptor = [self getBoxDescriptor:boxNumber isPlural:isPlural];
-    return [NSString stringWithFormat:@"%@ of %@%@", descriptor, action, [self getVerb]];
+    if (isPlural) {
+        return [NSString stringWithFormat:@"%@ of %@%@", descriptor, action, [self getVerb]];
+    }
+    NSString *singularVerbString;
+    if ([self.type isEqualToString:@"activity"]) {
+        singularVerbString = self.title;
+    }
+    else {
+        singularVerbString = [NSString stringWithFormat:@"%@ %@", self.getVerb, self.title];
+    }
+    return [NSString stringWithFormat:@"%@ of %@%@", descriptor, action, singularVerbString];
+
 }
 
 @end

--- a/CostBenefit/Resources/cba.txt
+++ b/CostBenefit/Resources/cba.txt
@@ -1,8 +1,5 @@
 A **Cost-Benefit Analysis (CBA)** is a tool for exploring the short-term vs. long-term benefits associated with continuing or discontinuing an addictive behavior.
 
-
-***
-
 ### 1. What do I enjoy about my addiction?
 
 #### What does it do for me?
@@ -15,8 +12,6 @@ List as many specific things as you can that you liked about whatever you are/we
 - List what you enjoy about your addiction so you can ask yourself if it is really worth the price.
 - Realize that you aren't stupid; you did get something from your addiction. It just may not be working on your behalf anymore.
 
-***
-
 ### 2. What do I hate about my addiction?
 
 #### What does it do to me?
@@ -25,8 +20,6 @@ List specific examples of many of the bad, undesirable results of your addiction
 - Ask yourself honestly: *"If my addiction was a used car, would I pay this much for it?"*
 - Review this list often, especially if you are having a lot of positive, happy thoughts about all the great things your addiction did for you.
 
-***
-
 ### 3. What do I think I will like about giving up my addiction?
 
 #### List what good things you think/fantasize will happen when you stop your addiction.
@@ -34,16 +27,12 @@ List specific examples of many of the bad, undesirable results of your addiction
 - This provides you with a list of goals to achieve and things to look forward to as a result of your new addiction free lifestyle.
 - This list also helps you to reality test your expectations. If they are unrealistic, they can lead to a disappointment-based relapse.
 
-***
-
 ### 4. What do I think I won't like about giving up my addiction?
 
-#### List what you think you are going to hate, dread or merely dislike about living without your addiction.
+#### List what you think you are going to hate, dread, or merely dislike about living without your addiction.
 
 - This list tells you what kinds of new coping skills, behaviors and lifestyle changes you need to develop in order to stay addiction free.
 - It also serves as another relapse warning list. If all you think about is how much life sucks now that you are not doing your addiction, you are in a relapse thought pattern that is just as dangerous as only focusing on what you liked about your addiction.
-
-***
 
 This is not a do once and forget about it exercise. It is an ongoing project. Most people simply can't remember all of the positive and negative aspects of addiction and recovery at any one time.
 

--- a/CostBenefit/Views/About/SMRAboutSmartRecoveryView.xib
+++ b/CostBenefit/Views/About/SMRAboutSmartRecoveryView.xib
@@ -27,36 +27,32 @@
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sJZ-AA-M8j">
                             <rect key="frame" x="8" y="8" width="239" height="21"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5PF-Hf-zag">
-                            <rect key="frame" x="8" y="51" width="239" height="30"/>
-                            <color key="backgroundColor" red="0.93333333330000001" green="0.93333333330000001" blue="0.93333333330000001" alpha="1" colorSpace="calibratedRGB"/>
+                            <rect key="frame" x="8" y="29" width="239" height="30"/>
                             <state key="normal" title="Visit smartrecovery.org on the web"/>
                             <connections>
                                 <action selector="websiteButtonTouchUpInside:" destination="-1" eventType="touchUpInside" id="LzO-Xb-4Q0"/>
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RAk-GN-Ele">
-                            <rect key="frame" x="8" y="103" width="113" height="30"/>
-                            <color key="backgroundColor" red="0.93333333330000001" green="0.93333333330000001" blue="0.93333333330000001" alpha="1" colorSpace="calibratedRGB"/>
+                            <rect key="frame" x="8" y="81" width="113" height="30"/>
                             <state key="normal" title="Facebook"/>
                             <connections>
                                 <action selector="facebookButtonTouchUpInside:" destination="-1" eventType="touchUpInside" id="5qq-em-JAg"/>
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ndp-7M-kb8">
-                            <rect key="frame" x="134" y="103" width="113" height="30"/>
-                            <color key="backgroundColor" red="0.93333333330000001" green="0.93333333330000001" blue="0.93333333330000001" alpha="1" colorSpace="calibratedRGB"/>
+                            <rect key="frame" x="134" y="81" width="113" height="30"/>
                             <state key="normal" title="Twitter"/>
                             <connections>
                                 <action selector="twitterButtonTouchUpInside:" destination="-1" eventType="touchUpInside" id="Bl8-eE-Y8Y"/>
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h9G-Md-msC">
-                            <rect key="frame" x="8" y="155" width="239" height="30"/>
-                            <color key="backgroundColor" red="0.93333333330000001" green="0.93333333330000001" blue="0.93333333330000001" alpha="1" colorSpace="calibratedRGB"/>
+                            <rect key="frame" x="8" y="133" width="239" height="30"/>
                             <state key="normal" title="Rate us on the App Store"/>
                             <connections>
                                 <action selector="appStoreButtonTouchUpInside:" destination="-1" eventType="touchUpInside" id="PRV-GH-Qc4"/>
@@ -69,7 +65,7 @@
                         <constraint firstItem="ndp-7M-kb8" firstAttribute="width" secondItem="RAk-GN-Ele" secondAttribute="width" id="74z-3D-DMn"/>
                         <constraint firstItem="RAk-GN-Ele" firstAttribute="leading" secondItem="TVU-9W-jtc" secondAttribute="leading" constant="8" id="E8d-nc-a1M"/>
                         <constraint firstItem="5PF-Hf-zag" firstAttribute="leading" secondItem="TVU-9W-jtc" secondAttribute="leading" constant="8" id="HHe-br-rd3"/>
-                        <constraint firstItem="5PF-Hf-zag" firstAttribute="top" secondItem="sJZ-AA-M8j" secondAttribute="bottom" constant="22" id="Ncr-E6-RL5"/>
+                        <constraint firstItem="5PF-Hf-zag" firstAttribute="top" secondItem="sJZ-AA-M8j" secondAttribute="bottom" id="Ncr-E6-RL5"/>
                         <constraint firstAttribute="trailing" secondItem="5PF-Hf-zag" secondAttribute="trailing" constant="8" id="PfS-8d-svq"/>
                         <constraint firstAttribute="trailing" secondItem="h9G-Md-msC" secondAttribute="trailing" constant="8" id="XF0-lb-Nhm"/>
                         <constraint firstItem="ndp-7M-kb8" firstAttribute="leading" secondItem="RAk-GN-Ele" secondAttribute="trailing" constant="13" id="XfE-bU-25K"/>

--- a/CostBenefit/Views/CostBenefit/SMRCostBenefitBoxTableViewCell.xib
+++ b/CostBenefit/Views/CostBenefit/SMRCostBenefitBoxTableViewCell.xib
@@ -8,42 +8,47 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="127" id="KGk-i7-Jjw" customClass="SMRCostBenefitBoxTableViewCell">
-            <rect key="frame" x="0.0" y="0.0" width="414" height="127"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="181" id="KGk-i7-Jjw" customClass="SMRCostBenefitBoxTableViewCell">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="181"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="414" height="126"/>
+                <rect key="frame" x="0.0" y="0.0" width="414" height="180"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="S27-GK-mV4">
-                        <rect key="frame" x="8" y="20" width="398" height="86"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="S27-GK-mV4">
+                        <rect key="frame" x="8" y="20" width="398" height="122"/>
                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MIy-oi-bKr">
-                        <rect key="frame" x="372" y="6" width="36" height="17"/>
-                        <color key="backgroundColor" red="0.93333333330000001" green="0.93333333330000001" blue="0.93333333330000001" alpha="1" colorSpace="calibratedRGB"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                        <nil key="highlightedColor"/>
-                    </label>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DQJ-vM-E7I" userLabel="Bottom border">
-                        <rect key="frame" x="0.0" y="123" width="414" height="4"/>
+                        <rect key="frame" x="0.0" y="177" width="414" height="4"/>
                         <color key="backgroundColor" red="0.93333333333333335" green="0.93333333333333335" blue="0.93333333333333335" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="4" id="QTh-pv-PPR"/>
                         </constraints>
                     </view>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MIy-oi-bKr">
+                        <rect key="frame" x="377" y="150" width="29" height="14"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                        <nil key="highlightedColor"/>
+                    </label>
                 </subviews>
                 <constraints>
                     <constraint firstAttribute="leadingMargin" secondItem="S27-GK-mV4" secondAttribute="leading" id="3Gc-iG-z8R"/>
-                    <constraint firstAttribute="trailingMargin" secondItem="MIy-oi-bKr" secondAttribute="trailing" constant="-2" id="OKR-9y-mAT"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="MIy-oi-bKr" secondAttribute="bottom" constant="8" id="GKh-hj-Lz3"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="MIy-oi-bKr" secondAttribute="trailing" id="OKR-9y-mAT"/>
                     <constraint firstItem="S27-GK-mV4" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" constant="12" id="PRU-Ie-pkp"/>
                     <constraint firstAttribute="trailingMargin" secondItem="S27-GK-mV4" secondAttribute="trailing" id="e0V-gH-vfC"/>
-                    <constraint firstItem="MIy-oi-bKr" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" constant="-2" id="g9P-sb-Kia"/>
                     <constraint firstAttribute="bottomMargin" secondItem="S27-GK-mV4" secondAttribute="bottom" constant="12" id="r9W-Qn-OFh"/>
+                    <constraint firstItem="MIy-oi-bKr" firstAttribute="top" secondItem="S27-GK-mV4" secondAttribute="bottom" constant="8" id="yWP-V6-kSo"/>
                 </constraints>
+                <variation key="default">
+                    <mask key="constraints">
+                        <exclude reference="r9W-Qn-OFh"/>
+                    </mask>
+                </variation>
             </tableViewCellContentView>
             <constraints>
                 <constraint firstAttribute="bottom" secondItem="DQJ-vM-E7I" secondAttribute="bottom" id="AZY-fX-Yw0"/>
@@ -54,7 +59,7 @@
                 <outlet property="longTermLabel" destination="MIy-oi-bKr" id="RJ8-KQ-B5A"/>
                 <outlet property="titleLabel" destination="S27-GK-mV4" id="fTY-79-NXp"/>
             </connections>
-            <point key="canvasLocation" x="315" y="385.5"/>
+            <point key="canvasLocation" x="315" y="412.5"/>
         </tableViewCell>
     </objects>
 </document>

--- a/CostBenefit/Views/CostBenefit/SMRCostBenefitBoxView.xib
+++ b/CostBenefit/Views/CostBenefit/SMRCostBenefitBoxView.xib
@@ -23,13 +23,14 @@
                     <rect key="frame" x="16" y="8" width="568" height="584"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ddR-zL-XbB">
-                            <rect key="frame" x="16" y="8" width="552" height="21"/>
-                            <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
-                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                            <rect key="frame" x="8" y="8" width="560" height="17"/>
+                            <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
+                            <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="128-Qo-N6E" userLabel="Edit Button">
-                            <rect key="frame" x="530" y="4" width="30" height="30"/>
+                            <rect key="frame" x="530" y="4" width="30" height="28"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="13"/>
                             <state key="normal" title="Edit"/>
                             <connections>
                                 <action selector="editBoxButtonTouchUpInside:" destination="-1" eventType="touchUpInside" id="BXQ-iU-mAE"/>
@@ -44,7 +45,7 @@
                             </connections>
                         </button>
                         <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="sNc-06-9Bw">
-                            <rect key="frame" x="4" y="45" width="560" height="492"/>
+                            <rect key="frame" x="4" y="41" width="560" height="496"/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             <connections>
                                 <outlet property="dataSource" destination="-1" id="XPk-4B-owj"/>
@@ -70,7 +71,7 @@
                         <constraint firstItem="B0R-Fe-QZg" firstAttribute="leading" secondItem="dxl-hz-wjy" secondAttribute="leading" constant="8" id="Lbk-J9-ZkF"/>
                         <constraint firstItem="ddR-zL-XbB" firstAttribute="top" secondItem="dxl-hz-wjy" secondAttribute="top" constant="8" id="SBs-oj-BV7"/>
                         <constraint firstItem="sNc-06-9Bw" firstAttribute="leading" secondItem="dxl-hz-wjy" secondAttribute="leading" constant="4" id="fnE-jR-zcg"/>
-                        <constraint firstItem="ddR-zL-XbB" firstAttribute="leading" secondItem="dxl-hz-wjy" secondAttribute="leading" constant="16" id="iNt-Za-TIA"/>
+                        <constraint firstItem="ddR-zL-XbB" firstAttribute="leading" secondItem="dxl-hz-wjy" secondAttribute="leading" constant="8" id="iNt-Za-TIA"/>
                         <constraint firstAttribute="trailing" secondItem="ddR-zL-XbB" secondAttribute="trailing" id="lru-14-aHR"/>
                         <constraint firstItem="128-Qo-N6E" firstAttribute="top" secondItem="dxl-hz-wjy" secondAttribute="top" constant="4" id="m4h-Ce-Ryy"/>
                         <constraint firstAttribute="bottom" secondItem="4gg-Sc-jkI" secondAttribute="bottom" id="oNC-29-0h1"/>

--- a/CostBenefit/Views/CostBenefit/SMREditCostBenefitItemView.xib
+++ b/CostBenefit/Views/CostBenefit/SMREditCostBenefitItemView.xib
@@ -34,7 +34,7 @@
                     </connections>
                 </textField>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" bounces="NO" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="8Rm-aZ-6tV">
-                    <rect key="frame" x="8" y="107" width="584" height="375"/>
+                    <rect key="frame" x="8" y="107" width="568" height="375"/>
                     <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                     <connections>
                         <outlet property="dataSource" destination="-1" id="wuQ-2n-0Iu"/>
@@ -60,7 +60,7 @@
                 <constraint firstItem="XIp-FU-VQY" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="Yr3-jJ-BoI"/>
                 <constraint firstAttribute="trailing" secondItem="hea-jx-lX5" secondAttribute="trailing" constant="8" id="ZZz-5U-vof"/>
                 <constraint firstItem="dxa-Fy-ccz" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="dmu-7m-iwp"/>
-                <constraint firstAttribute="trailing" secondItem="8Rm-aZ-6tV" secondAttribute="trailing" constant="8" id="g3k-cq-Qp2"/>
+                <constraint firstAttribute="trailing" secondItem="8Rm-aZ-6tV" secondAttribute="trailing" constant="24" id="g3k-cq-Qp2"/>
                 <constraint firstItem="8Rm-aZ-6tV" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="iWR-vN-Soj"/>
                 <constraint firstAttribute="bottom" secondItem="hea-jx-lX5" secondAttribute="bottom" constant="44" id="pUS-Ty-qZ4"/>
                 <constraint firstItem="dxa-Fy-ccz" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="44" id="rat-5t-1Wl"/>

--- a/CostBenefit/Views/CostBenefit/SMREditCostBenefitItemView.xib
+++ b/CostBenefit/Views/CostBenefit/SMREditCostBenefitItemView.xib
@@ -26,7 +26,10 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="XIp-FU-VQY">
-                    <rect key="frame" x="8" y="69" width="584" height="30"/>
+                    <rect key="frame" x="8" y="69" width="584" height="50"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="50" id="2OP-Xf-uPk"/>
+                    </constraints>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences" returnKeyType="done"/>
                     <connections>
@@ -34,7 +37,7 @@
                     </connections>
                 </textField>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" bounces="NO" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="8Rm-aZ-6tV">
-                    <rect key="frame" x="8" y="107" width="568" height="375"/>
+                    <rect key="frame" x="8" y="127" width="568" height="355"/>
                     <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                     <connections>
                         <outlet property="dataSource" destination="-1" id="wuQ-2n-0Iu"/>

--- a/CostBenefit/Views/CostBenefit/SMREditCostBenefitItemView.xib
+++ b/CostBenefit/Views/CostBenefit/SMREditCostBenefitItemView.xib
@@ -9,7 +9,6 @@
             <connections>
                 <outlet property="boxDescriptionLabel" destination="dxa-Fy-ccz" id="5Rn-HM-aRZ"/>
                 <outlet property="costBenefitItemTitleField" destination="XIp-FU-VQY" id="1qP-bA-CVf"/>
-                <outlet property="deleteButton" destination="hea-jx-lX5" id="Wxd-2L-37s"/>
                 <outlet property="tableView" destination="8Rm-aZ-6tV" id="C4t-C8-ext"/>
                 <outlet property="view" destination="iN0-l3-epB" id="HJw-FA-RBH"/>
             </connections>
@@ -37,38 +36,26 @@
                     </connections>
                 </textField>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" bounces="NO" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="8Rm-aZ-6tV">
-                    <rect key="frame" x="8" y="127" width="568" height="355"/>
+                    <rect key="frame" x="8" y="127" width="568" height="473"/>
                     <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                     <connections>
                         <outlet property="dataSource" destination="-1" id="wuQ-2n-0Iu"/>
                         <outlet property="delegate" destination="-1" id="tZp-Ik-byE"/>
                     </connections>
                 </tableView>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hea-jx-lX5">
-                    <rect key="frame" x="8" y="526" width="584" height="30"/>
-                    <state key="normal" title="Delete Item">
-                        <color key="titleColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                    </state>
-                    <connections>
-                        <action selector="deleteButtonTouchUpInside:" destination="-1" eventType="touchUpInside" id="L2r-Ux-OHg"/>
-                    </connections>
-                </button>
             </subviews>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
             <constraints>
-                <constraint firstItem="hea-jx-lX5" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="AYz-Kl-1qH"/>
                 <constraint firstAttribute="trailing" secondItem="dxa-Fy-ccz" secondAttribute="trailing" constant="8" id="CQo-63-VyG"/>
+                <constraint firstAttribute="bottom" secondItem="8Rm-aZ-6tV" secondAttribute="bottom" id="Nr4-EO-dmy"/>
                 <constraint firstAttribute="trailing" secondItem="XIp-FU-VQY" secondAttribute="trailing" constant="8" id="REy-0W-dUI"/>
                 <constraint firstItem="XIp-FU-VQY" firstAttribute="top" secondItem="dxa-Fy-ccz" secondAttribute="bottom" constant="8" id="RRV-Ba-i8X"/>
                 <constraint firstItem="XIp-FU-VQY" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="Yr3-jJ-BoI"/>
-                <constraint firstAttribute="trailing" secondItem="hea-jx-lX5" secondAttribute="trailing" constant="8" id="ZZz-5U-vof"/>
                 <constraint firstItem="dxa-Fy-ccz" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="dmu-7m-iwp"/>
                 <constraint firstAttribute="trailing" secondItem="8Rm-aZ-6tV" secondAttribute="trailing" constant="24" id="g3k-cq-Qp2"/>
                 <constraint firstItem="8Rm-aZ-6tV" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="iWR-vN-Soj"/>
-                <constraint firstAttribute="bottom" secondItem="hea-jx-lX5" secondAttribute="bottom" constant="44" id="pUS-Ty-qZ4"/>
                 <constraint firstItem="dxa-Fy-ccz" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="44" id="rat-5t-1Wl"/>
                 <constraint firstItem="8Rm-aZ-6tV" firstAttribute="top" secondItem="XIp-FU-VQY" secondAttribute="bottom" constant="8" id="u4V-Yb-7aE"/>
-                <constraint firstItem="hea-jx-lX5" firstAttribute="top" secondItem="8Rm-aZ-6tV" secondAttribute="bottom" constant="44" id="ubV-Yw-pi2"/>
             </constraints>
         </view>
     </objects>

--- a/CostBenefit/Views/CostBenefit/SMREditCostBenefitItemView.xib
+++ b/CostBenefit/Views/CostBenefit/SMREditCostBenefitItemView.xib
@@ -25,10 +25,10 @@
                     <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="XIp-FU-VQY">
+                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="XIp-FU-VQY">
                     <rect key="frame" x="8" y="69" width="584" height="30"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <textInputTraits key="textInputTraits" returnKeyType="done"/>
+                    <textInputTraits key="textInputTraits" autocapitalizationType="sentences" returnKeyType="done"/>
                     <connections>
                         <action selector="CostBenefitItemTitleFieldEditingChanged:" destination="-1" eventType="editingChanged" id="KgA-Ra-pxm"/>
                     </connections>

--- a/CostBenefit/Views/CostBenefit/SMREditCostBenefitItemView.xib
+++ b/CostBenefit/Views/CostBenefit/SMREditCostBenefitItemView.xib
@@ -20,13 +20,13 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dxa-Fy-ccz">
-                    <rect key="frame" x="8" y="16" width="584" height="17"/>
+                    <rect key="frame" x="8" y="44" width="584" height="17"/>
                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                     <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="XIp-FU-VQY">
-                    <rect key="frame" x="8" y="41" width="584" height="30"/>
+                    <rect key="frame" x="8" y="69" width="584" height="30"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <textInputTraits key="textInputTraits" returnKeyType="done"/>
                     <connections>
@@ -34,7 +34,7 @@
                     </connections>
                 </textField>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" bounces="NO" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="8Rm-aZ-6tV">
-                    <rect key="frame" x="8" y="79" width="584" height="403"/>
+                    <rect key="frame" x="8" y="107" width="584" height="375"/>
                     <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                     <connections>
                         <outlet property="dataSource" destination="-1" id="wuQ-2n-0Iu"/>
@@ -63,7 +63,7 @@
                 <constraint firstAttribute="trailing" secondItem="8Rm-aZ-6tV" secondAttribute="trailing" constant="8" id="g3k-cq-Qp2"/>
                 <constraint firstItem="8Rm-aZ-6tV" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="iWR-vN-Soj"/>
                 <constraint firstAttribute="bottom" secondItem="hea-jx-lX5" secondAttribute="bottom" constant="44" id="pUS-Ty-qZ4"/>
-                <constraint firstItem="dxa-Fy-ccz" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="16" id="rat-5t-1Wl"/>
+                <constraint firstItem="dxa-Fy-ccz" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="44" id="rat-5t-1Wl"/>
                 <constraint firstItem="8Rm-aZ-6tV" firstAttribute="top" secondItem="XIp-FU-VQY" secondAttribute="bottom" constant="8" id="u4V-Yb-7aE"/>
                 <constraint firstItem="hea-jx-lX5" firstAttribute="top" secondItem="8Rm-aZ-6tV" secondAttribute="bottom" constant="44" id="ubV-Yw-pi2"/>
             </constraints>

--- a/CostBenefit/Views/CostBenefit/SMREditCostBenefitItemView.xib
+++ b/CostBenefit/Views/CostBenefit/SMREditCostBenefitItemView.xib
@@ -19,14 +19,14 @@
             <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dxa-Fy-ccz">
-                    <rect key="frame" x="8" y="16" width="584" height="21"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dxa-Fy-ccz">
+                    <rect key="frame" x="8" y="16" width="584" height="17"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                    <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="XIp-FU-VQY">
-                    <rect key="frame" x="8" y="45" width="584" height="30"/>
+                    <rect key="frame" x="8" y="41" width="584" height="30"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <textInputTraits key="textInputTraits" returnKeyType="done"/>
                     <connections>
@@ -34,7 +34,7 @@
                     </connections>
                 </textField>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" bounces="NO" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="8Rm-aZ-6tV">
-                    <rect key="frame" x="8" y="83" width="584" height="399"/>
+                    <rect key="frame" x="8" y="79" width="584" height="403"/>
                     <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                     <connections>
                         <outlet property="dataSource" destination="-1" id="wuQ-2n-0Iu"/>

--- a/CostBenefit/Views/CostBenefit/SMREditCostBenefitView.xib
+++ b/CostBenefit/Views/CostBenefit/SMREditCostBenefitView.xib
@@ -9,6 +9,7 @@
             <connections>
                 <outlet property="tableView" destination="Cjr-t8-2g4" id="j1e-Nn-VeO"/>
                 <outlet property="titleTextField" destination="nvq-ZQ-VYG" id="V4e-wR-PKh"/>
+                <outlet property="titleTextFieldLabel" destination="M1m-Xe-ZMy" id="Osy-v2-9v2"/>
                 <outlet property="view" destination="iN0-l3-epB" id="Wlu-ru-Iwj"/>
             </connections>
         </placeholder>
@@ -17,22 +18,8 @@
             <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="nvq-ZQ-VYG">
-                    <rect key="frame" x="8" y="148" width="584" height="30"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <textInputTraits key="textInputTraits" returnKeyType="done"/>
-                    <connections>
-                        <action selector="titleTextFieldEditingChanged:" destination="-1" eventType="editingChanged" id="dUb-EJ-vLo"/>
-                    </connections>
-                </textField>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="to consider is:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="M1m-Xe-ZMy">
-                    <rect key="frame" x="8" y="111" width="584" height="21"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                    <nil key="highlightedColor"/>
-                </label>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Cjr-t8-2g4">
-                    <rect key="frame" x="-8" y="7" width="608" height="88"/>
+                    <rect key="frame" x="-8" y="8" width="608" height="88"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="88" id="4hm-th-uKh"/>
@@ -42,6 +29,20 @@
                         <outlet property="delegate" destination="-1" id="PhX-KK-kQq"/>
                     </connections>
                 </tableView>
+                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="nvq-ZQ-VYG">
+                    <rect key="frame" x="8" y="144" width="584" height="30"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <textInputTraits key="textInputTraits" returnKeyType="done"/>
+                    <connections>
+                        <action selector="titleTextFieldEditingChanged:" destination="-1" eventType="editingChanged" id="dUb-EJ-vLo"/>
+                    </connections>
+                </textField>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="to consider is:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="M1m-Xe-ZMy">
+                    <rect key="frame" x="8" y="112" width="584" height="16"/>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
+                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                    <nil key="highlightedColor"/>
+                </label>
             </subviews>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
             <constraints>
@@ -52,7 +53,7 @@
                 <constraint firstItem="Cjr-t8-2g4" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="-8" id="TcT-eQ-neg"/>
                 <constraint firstItem="nvq-ZQ-VYG" firstAttribute="top" secondItem="M1m-Xe-ZMy" secondAttribute="bottom" constant="16" id="bwL-6I-NJF"/>
                 <constraint firstAttribute="trailing" secondItem="M1m-Xe-ZMy" secondAttribute="trailing" constant="8" id="lAv-Vi-3TC"/>
-                <constraint firstItem="Cjr-t8-2g4" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="7" id="tUW-aL-Acb"/>
+                <constraint firstItem="Cjr-t8-2g4" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="8" id="tUW-aL-Acb"/>
                 <constraint firstItem="M1m-Xe-ZMy" firstAttribute="top" secondItem="Cjr-t8-2g4" secondAttribute="bottom" constant="16" id="xTY-5Q-0cW"/>
             </constraints>
         </view>

--- a/CostBenefit/Views/CostBenefit/SMREditCostBenefitView.xib
+++ b/CostBenefit/Views/CostBenefit/SMREditCostBenefitView.xib
@@ -23,7 +23,7 @@
                     <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="co7-pZ-8e0">
-                            <rect key="frame" x="0.0" y="0.0" width="600" height="228"/>
+                            <rect key="frame" x="0.0" y="0.0" width="600" height="248"/>
                             <subviews>
                                 <tableView clipsSubviews="YES" contentMode="scaleToFill" bounces="NO" alwaysBounceVertical="YES" scrollEnabled="NO" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Cjr-t8-2g4">
                                     <rect key="frame" x="0.0" y="22" width="592" height="88"/>
@@ -43,7 +43,10 @@
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="center" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="nvq-ZQ-VYG">
-                                    <rect key="frame" x="8" y="164" width="584" height="30"/>
+                                    <rect key="frame" x="8" y="164" width="584" height="50"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="50" id="D4X-Xl-NXb"/>
+                                    </constraints>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences" returnKeyType="done"/>
                                     <connections>

--- a/CostBenefit/Views/CostBenefit/SMREditCostBenefitView.xib
+++ b/CostBenefit/Views/CostBenefit/SMREditCostBenefitView.xib
@@ -42,10 +42,10 @@
                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="nvq-ZQ-VYG">
+                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="center" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="nvq-ZQ-VYG">
                                     <rect key="frame" x="8" y="164" width="584" height="30"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                    <textInputTraits key="textInputTraits" returnKeyType="done"/>
+                                    <textInputTraits key="textInputTraits" autocapitalizationType="sentences" returnKeyType="done"/>
                                     <connections>
                                         <action selector="titleTextFieldEditingChanged:" destination="-1" eventType="editingChanged" id="dUb-EJ-vLo"/>
                                     </connections>

--- a/CostBenefit/Views/CostBenefit/SMREditCostBenefitView.xib
+++ b/CostBenefit/Views/CostBenefit/SMREditCostBenefitView.xib
@@ -7,6 +7,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SMREditCostBenefitViewController">
             <connections>
+                <outlet property="scrollView" destination="WAd-I9-A4K" id="nZR-2I-nU1"/>
                 <outlet property="tableView" destination="Cjr-t8-2g4" id="j1e-Nn-VeO"/>
                 <outlet property="titleTextField" destination="nvq-ZQ-VYG" id="V4e-wR-PKh"/>
                 <outlet property="titleTextFieldLabel" destination="M1m-Xe-ZMy" id="Osy-v2-9v2"/>
@@ -18,43 +19,68 @@
             <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Cjr-t8-2g4">
-                    <rect key="frame" x="-8" y="8" width="608" height="88"/>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WAd-I9-A4K">
+                    <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="co7-pZ-8e0">
+                            <rect key="frame" x="0.0" y="0.0" width="600" height="228"/>
+                            <subviews>
+                                <tableView clipsSubviews="YES" contentMode="scaleToFill" bounces="NO" alwaysBounceVertical="YES" scrollEnabled="NO" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Cjr-t8-2g4">
+                                    <rect key="frame" x="0.0" y="22" width="592" height="88"/>
+                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="88" id="4hm-th-uKh"/>
+                                    </constraints>
+                                    <connections>
+                                        <outlet property="dataSource" destination="-1" id="Faz-5J-lNM"/>
+                                        <outlet property="delegate" destination="-1" id="PhX-KK-kQq"/>
+                                    </connections>
+                                </tableView>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="to consider is:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="M1m-Xe-ZMy">
+                                    <rect key="frame" x="0.0" y="132" width="600" height="16"/>
+                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
+                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="nvq-ZQ-VYG">
+                                    <rect key="frame" x="8" y="164" width="584" height="30"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <textInputTraits key="textInputTraits" returnKeyType="done"/>
+                                    <connections>
+                                        <action selector="titleTextFieldEditingChanged:" destination="-1" eventType="editingChanged" id="dUb-EJ-vLo"/>
+                                    </connections>
+                                </textField>
+                            </subviews>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <constraints>
+                                <constraint firstItem="nvq-ZQ-VYG" firstAttribute="leading" secondItem="co7-pZ-8e0" secondAttribute="leading" constant="8" id="A21-sj-LtZ"/>
+                                <constraint firstItem="nvq-ZQ-VYG" firstAttribute="top" secondItem="M1m-Xe-ZMy" secondAttribute="bottom" constant="16" id="F5i-ss-RyZ"/>
+                                <constraint firstItem="Cjr-t8-2g4" firstAttribute="top" secondItem="co7-pZ-8e0" secondAttribute="top" constant="22" id="Kks-bH-5lv"/>
+                                <constraint firstItem="M1m-Xe-ZMy" firstAttribute="top" secondItem="Cjr-t8-2g4" secondAttribute="bottom" constant="22" id="MpU-ZJ-dhw"/>
+                                <constraint firstAttribute="trailing" secondItem="nvq-ZQ-VYG" secondAttribute="trailing" constant="8" id="Rhx-5p-899"/>
+                                <constraint firstAttribute="bottom" secondItem="nvq-ZQ-VYG" secondAttribute="bottom" constant="34" id="Vf9-zU-CEi"/>
+                                <constraint firstItem="Cjr-t8-2g4" firstAttribute="leading" secondItem="co7-pZ-8e0" secondAttribute="leading" id="ac2-Mi-8p9"/>
+                                <constraint firstItem="M1m-Xe-ZMy" firstAttribute="leading" secondItem="co7-pZ-8e0" secondAttribute="leading" id="jpJ-3e-vIV"/>
+                                <constraint firstAttribute="trailing" secondItem="Cjr-t8-2g4" secondAttribute="trailing" constant="8" id="lO9-fr-5JP"/>
+                                <constraint firstAttribute="trailing" secondItem="M1m-Xe-ZMy" secondAttribute="trailing" id="u1r-2m-ZV3"/>
+                            </constraints>
+                        </view>
+                    </subviews>
                     <constraints>
-                        <constraint firstAttribute="height" constant="88" id="4hm-th-uKh"/>
+                        <constraint firstAttribute="trailing" secondItem="co7-pZ-8e0" secondAttribute="trailing" id="8ql-BQ-f0k"/>
+                        <constraint firstItem="co7-pZ-8e0" firstAttribute="top" secondItem="WAd-I9-A4K" secondAttribute="top" id="GC1-bV-rd1"/>
+                        <constraint firstItem="co7-pZ-8e0" firstAttribute="leading" secondItem="WAd-I9-A4K" secondAttribute="leading" id="OeU-8M-oce"/>
+                        <constraint firstAttribute="bottom" secondItem="co7-pZ-8e0" secondAttribute="bottom" id="YGb-QE-UmQ"/>
+                        <constraint firstItem="co7-pZ-8e0" firstAttribute="width" secondItem="WAd-I9-A4K" secondAttribute="width" id="ked-uJ-P7G"/>
                     </constraints>
-                    <connections>
-                        <outlet property="dataSource" destination="-1" id="Faz-5J-lNM"/>
-                        <outlet property="delegate" destination="-1" id="PhX-KK-kQq"/>
-                    </connections>
-                </tableView>
-                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="nvq-ZQ-VYG">
-                    <rect key="frame" x="8" y="144" width="584" height="30"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <textInputTraits key="textInputTraits" returnKeyType="done"/>
-                    <connections>
-                        <action selector="titleTextFieldEditingChanged:" destination="-1" eventType="editingChanged" id="dUb-EJ-vLo"/>
-                    </connections>
-                </textField>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="to consider is:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="M1m-Xe-ZMy">
-                    <rect key="frame" x="8" y="112" width="584" height="16"/>
-                    <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
-                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                    <nil key="highlightedColor"/>
-                </label>
+                </scrollView>
             </subviews>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
             <constraints>
-                <constraint firstItem="nvq-ZQ-VYG" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="5Kc-Fl-fOC"/>
-                <constraint firstAttribute="trailing" secondItem="nvq-ZQ-VYG" secondAttribute="trailing" constant="8" id="Ghd-Jq-eNo"/>
-                <constraint firstAttribute="trailing" secondItem="Cjr-t8-2g4" secondAttribute="trailing" id="ImU-12-Hxv"/>
-                <constraint firstItem="M1m-Xe-ZMy" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="JZ2-vJ-4WI"/>
-                <constraint firstItem="Cjr-t8-2g4" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="-8" id="TcT-eQ-neg"/>
-                <constraint firstItem="nvq-ZQ-VYG" firstAttribute="top" secondItem="M1m-Xe-ZMy" secondAttribute="bottom" constant="16" id="bwL-6I-NJF"/>
-                <constraint firstAttribute="trailing" secondItem="M1m-Xe-ZMy" secondAttribute="trailing" constant="8" id="lAv-Vi-3TC"/>
-                <constraint firstItem="Cjr-t8-2g4" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="8" id="tUW-aL-Acb"/>
-                <constraint firstItem="M1m-Xe-ZMy" firstAttribute="top" secondItem="Cjr-t8-2g4" secondAttribute="bottom" constant="16" id="xTY-5Q-0cW"/>
+                <constraint firstAttribute="bottom" secondItem="WAd-I9-A4K" secondAttribute="bottom" id="NJF-Qw-hF3"/>
+                <constraint firstItem="WAd-I9-A4K" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="Rb4-Jx-GAs"/>
+                <constraint firstItem="WAd-I9-A4K" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="c09-q5-VS2"/>
+                <constraint firstAttribute="trailing" secondItem="WAd-I9-A4K" secondAttribute="trailing" id="g3s-8f-Rld"/>
             </constraints>
         </view>
     </objects>


### PR DESCRIPTION
- Fixes #48 - gets Add / Edit screens looking better, and refactors delete functionality as `UIBarButtonItem` available on Edit screens' toolbar
- Adds `scrollView` to `SMREditCostBenefitViewController` to avoid keyboard hiding the textField on iPhone 4S
- Display keyboard in `viewDidAppear` on New screens for better UX
- Fixes #65 for now - use capitalization suggestions for CostBenefit title / Item titles
- Tweaks to fonts/styles, About view controllers'
