### PR TITLE
Set new CostBenefitItem seq to count

### DIFF
--- a/CostBenefit/Controllers/CostBenefit/SMRCostBenefitBoxViewController.m
+++ b/CostBenefit/Controllers/CostBenefit/SMRCostBenefitBoxViewController.m
@@ -104,6 +104,7 @@
     costBenefitItem.boxNumber = self.boxNumber;
     costBenefitItem.costBenefit = self.costBenefit;
     costBenefitItem.isLongTerm = [NSNumber numberWithBool:YES];
+    costBenefitItem.seq = [NSNumber numberWithLong:(long)self.costBenefitItems.count * 10];
     SMREditCostBenefitItemViewController *addItemVC = [[SMREditCostBenefitItemViewController alloc] initWithCostBenefitItem:costBenefitItem isNew:YES managedObjectContext:self.managedObjectContext];
     UINavigationController *navVC = [[UINavigationController alloc] initWithRootViewController:addItemVC];
     navVC.navigationBar.translucent = NO;
@@ -122,11 +123,11 @@
 }
 
 - (void)finishEditing {
-  if (self.didEditBox) {
+    if (self.didEditBox) {
         for (int i = 0; i < self.costBenefitItems.count; i++) {
             NSIndexPath *indexPath =[NSIndexPath indexPathForRow:i inSection:0];
             SMRCostBenefitBoxTableViewCell *cell = [self.tableView cellForRowAtIndexPath:indexPath];
-            cell.costBenefitItem.seq = [NSNumber numberWithInt:i];
+            cell.costBenefitItem.seq = [NSNumber numberWithInt:i * 10];
         }
         NSError *error;
         [self.managedObjectContext save:&error];

--- a/CostBenefit/Controllers/CostBenefit/SMRCostBenefitViewController.m
+++ b/CostBenefit/Controllers/CostBenefit/SMRCostBenefitViewController.m
@@ -40,7 +40,7 @@
 - (void)setManagedObjectContext:(NSManagedObjectContext *)managedObjectContext {
     _managedObjectContext = managedObjectContext;
     self.title = self.costBenefit.title;
-    for (int i=0; i < 4; i++) {
+    for (int i = 0; i < 4; i++) {
         SMRCostBenefitBoxViewController *boxVC = self.boxViewControllers[i];
         boxVC.managedObjectContext = managedObjectContext;
         [boxVC reloadData];

--- a/CostBenefit/Controllers/CostBenefit/SMREditCostBenefitItemViewController.m
+++ b/CostBenefit/Controllers/CostBenefit/SMREditCostBenefitItemViewController.m
@@ -89,8 +89,6 @@
 
 - (void)saveButtonTouchUpInside:(id)sender {
     self.costBenefitItem.title = [self.costBenefitItemTitleField.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-    // @todo: This should be calculated to go to the end... or first
-    self.costBenefitItem.seq = [NSNumber numberWithInt:10];
     self.costBenefitItem.costBenefit.dateUpdated = [[NSDate alloc] init];
     if (self.isNew) {
         self.costBenefitItem.dateCreated = [[NSDate alloc] init];
@@ -120,7 +118,7 @@
 - (IBAction)deleteButtonTouchUpInside:(id)sender {
     UIAlertController *confirmDeleteAlertController = [UIAlertController alertControllerWithTitle:@"Are you sure you want to delete this item?" message:@"This cannot be undone." preferredStyle:UIAlertControllerStyleAlert];
     UIAlertAction *deleteAction = [UIAlertAction actionWithTitle:@"Delete" style:UIAlertActionStyleDestructive handler:^(UIAlertAction * action) {
-        self.costBenefitItem.costBenefit.dateUpdated = [[NSDate alloc ] init];
+        self.costBenefitItem.costBenefit.dateUpdated = [[NSDate alloc] init];
         [self.costBenefitItem.costBenefit removeCostBenefitItemsObject:self.costBenefitItem];
         [self.managedObjectContext deleteObject:self.costBenefitItem];
         NSError *error;


### PR DESCRIPTION
Fixes #77 by setting new CostBenefitItem seq to the total count. Multiply everything by 10 to avoid potential bugs with legacy data, where all `seq` was set to 10 and never editable. Without the multiplication, new items may end up at the end of list upon insertion.
